### PR TITLE
Use proper JSDoc syntax for optional parameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,8 +27,8 @@ AsyncLock.DEFAULT_MAX_PENDING = 1000;
  *
  * @param {String|Array} key 	resource key or keys to lock
  * @param {function} fn 	async function
- * @param {function} cb 	(optional) callback function, otherwise will return a promise
- * @param {Object} opts 	(optional) options
+ * @param {function} [cb] 	(optional) callback function, otherwise will return a promise
+ * @param {Object} [opts] 	(optional) options
  */
 AsyncLock.prototype.acquire = function(key, fn, cb, opts){
     if(Array.isArray(key)){
@@ -211,7 +211,7 @@ AsyncLock.prototype._acquireBatch = function(keys, fn, cb, opts){
 /*
  *	Whether there is any running or pending asyncFunc
  *
- *	@param {String} key (Optional)
+ *	@param {String} [key] (Optional)
  */
 AsyncLock.prototype.isBusy = function(key){
 	if(!key){


### PR DESCRIPTION
This prevents warnings in IDEs.
